### PR TITLE
Name the power basis on the HVDC loss curves

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -51,7 +51,7 @@ PowerDynamicsOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpe
 PowerInvestmentsOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "main", subdir = "PowerInvestmentsOpenAPIModels.jl"}
 PowerOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "main", subdir = "PowerOpenAPIModels.jl"}
 PowerOperationsOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "main", subdir = "PowerOperationsOpenAPIModels.jl"}
-InfrastructureSystems = {url = "https://github.com/Sienna-Platform/InfrastructureSystems.jl.git", rev = "IS4"}
+InfrastructureSystems = {url = "https://github.com/Sienna-Platform/InfrastructureSystems.jl.git", rev = "lk/loss-curve-units-v2"}
 PowerFlowFileParser = {url = "https://github.com/Sienna-Platform/PowerFlowFileParser.jl", rev = "psy6"}
 # CO-DEV PIN (temporary): `LossCurve` on the loss fields lands with the PSY PR that pins
 # this branch back. Revert to `psy6` once that merges.

--- a/Project.toml
+++ b/Project.toml
@@ -53,7 +53,9 @@ PowerOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIMode
 PowerOperationsOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "main", subdir = "PowerOperationsOpenAPIModels.jl"}
 InfrastructureSystems = {url = "https://github.com/Sienna-Platform/InfrastructureSystems.jl.git", rev = "IS4"}
 PowerFlowFileParser = {url = "https://github.com/Sienna-Platform/PowerFlowFileParser.jl", rev = "psy6"}
-PowerSystems = {url = "https://github.com/Sienna-Platform/PowerSystems.jl", rev = "psy6"}
+# CO-DEV PIN (temporary): `LossCurve` on the loss fields lands with the PSY PR that pins
+# this branch back. Revert to `psy6` once that merges.
+PowerSystems = {url = "https://github.com/Sienna-Platform/PowerSystems.jl", rev = "lk/loss-curve-type"}
 PowerTableDataParser = {url = "https://github.com/NLR-Sienna/PowerTableDataParser.jl", rev = "psy6"}
 
 [compat]

--- a/src/library/psi_library.jl
+++ b/src/library/psi_library.jl
@@ -1532,7 +1532,7 @@ function _duplicate_system(main_sys::PSY.System, twin_sys::PSY.System, HVDC_line
             active_power_limits_to = (min = -1000.0, max = 1000.0),
             reactive_power_limits_from = (min = -1000.0, max = 1000.0),
             reactive_power_limits_to = (min = -1000.0, max = 1000.0),
-            loss = PSY.LinearCurve(0.1),
+            loss = PSY.LossCurve(PSY.LinearCurve(0.1), PSY.NaturalUnit()),
             services = Vector{Service}[],
             ext = Dict{String, Any}(),
         )
@@ -1972,10 +1972,9 @@ function build_MTHVDC_two_RTS_DA_sys_noForecast(; kwargs...)
             rating = 1.0,
             active_power_limits = (min = 0.0, max = 1.0),
             base_power = P_limit_7T[ix],
-            loss_function = PSY.QuadraticCurve(
-                c_pu[ix],
-                b_pu[ix],
-                a_pu[ix],
+            loss_function = PSY.LossCurve(
+                PSY.QuadraticCurve(c_pu[ix], b_pu[ix], a_pu[ix]),
+                PSY.NaturalUnit(),
             ),
         )
         PSY.add_component!(sys, ipc)
@@ -1993,10 +1992,9 @@ function build_MTHVDC_two_RTS_DA_sys_noForecast(; kwargs...)
             rating = 1.0,
             active_power_limits = (min = 0.0, max = 1.0),
             base_power = P_limit_9T,
-            loss_function = PSY.QuadraticCurve(
-                c_pu_9T,
-                b_pu_9T,
-                a_pu_9T,
+            loss_function = PSY.LossCurve(
+                PSY.QuadraticCurve(c_pu_9T, b_pu_9T, a_pu_9T),
+                PSY.NaturalUnit(),
             ),
         )
         PSY.add_component!(sys, ipc)

--- a/src/parsers/power_models_data.jl
+++ b/src/parsers/power_models_data.jl
@@ -1725,6 +1725,13 @@ function read_3w_transformer!(
     end
 end
 
+# PSY's loss fields are `LossCurve`s, which name the basis their curve is on. Input
+# documents carry a bare curve, so one is supplied here: these parsers read MW-denominated
+# loss coefficients, which is `NaturalUnit`. A value that already arrives as a `LossCurve`
+# keeps the basis it came with.
+_as_loss_curve(loss::AnyLossCurve) = loss
+_as_loss_curve(curve::ValueCurve) = LossCurve(curve, NaturalUnit())
+
 function make_dcline(name::String, d::Dict, bus_f::ACBus, bus_t::ACBus, source_type::String)
     if source_type == "pti"
         return TwoTerminalLCCLine(;
@@ -1765,7 +1772,7 @@ function make_dcline(name::String, d::Dict, bus_f::ACBus, bus_t::ACBus, source_t
             active_power_limits_to = d["active_power_limits_to"],
             reactive_power_limits_from = d["reactive_power_limits_from"],
             reactive_power_limits_to = d["reactive_power_limits_to"],
-            loss = LinearCurve(d["loss1"], d["loss0"]),
+            loss = LossCurve(LinearCurve(d["loss1"], d["loss0"]), NaturalUnit()),
             ext = get(d, "ext", Dict{String, Any}()),
         )
     elseif source_type == "matpower"
@@ -1778,7 +1785,7 @@ function make_dcline(name::String, d::Dict, bus_f::ACBus, bus_t::ACBus, source_t
             active_power_limits_to = (min = d["pmint"], max = d["pmaxt"]),
             reactive_power_limits_from = (min = d["qminf"], max = d["qmaxf"]),
             reactive_power_limits_to = (min = d["qmint"], max = d["qmaxt"]),
-            loss = LinearCurve(d["loss1"], d["loss0"]),
+            loss = LossCurve(LinearCurve(d["loss1"], d["loss0"]), NaturalUnit()),
         )
     else
         error("Not supported source type for DC lines: $source_type")
@@ -1847,7 +1854,7 @@ function make_vscline(name::String, d::Dict, bus_f::ACBus, bus_t::ACBus)
         end,
         dc_setpoint_from = d["dc_setpoint_from"],
         ac_setpoint_from = d["ac_setpoint_from"],
-        converter_loss_from = d["converter_loss_from"],
+        converter_loss_from = _as_loss_curve(d["converter_loss_from"]),
         max_dc_current_from = d["max_dc_current_from"],
         rating_from = d["rating_from"],
         reactive_power_limits_from = (min = d["qminf"], max = d["qmaxf"]),
@@ -1867,7 +1874,7 @@ function make_vscline(name::String, d::Dict, bus_f::ACBus, bus_t::ACBus)
         end,
         dc_setpoint_to = d["dc_setpoint_to"],
         ac_setpoint_to = d["ac_setpoint_to"],
-        converter_loss_to = d["converter_loss_to"],
+        converter_loss_to = _as_loss_curve(d["converter_loss_to"]),
         max_dc_current_to = d["max_dc_current_to"],
         rating_to = d["rating_to"],
         remote_bus_control_to = _psse_remote_bus(d, "REMOT_TO"),

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -37,7 +37,7 @@ PowerDynamicsOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpe
 PowerInvestmentsOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "main", subdir = "PowerInvestmentsOpenAPIModels.jl"}
 PowerOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "main", subdir = "PowerOpenAPIModels.jl"}
 PowerOperationsOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "main", subdir = "PowerOperationsOpenAPIModels.jl"}
-InfrastructureSystems = {url = "https://github.com/Sienna-Platform/InfrastructureSystems.jl.git", rev = "IS4"}
+InfrastructureSystems = {url = "https://github.com/Sienna-Platform/InfrastructureSystems.jl.git", rev = "lk/loss-curve-units-v2"}
 PowerFlowFileParser = {url = "https://github.com/Sienna-Platform/PowerFlowFileParser.jl", rev = "psy6"}
 PowerSystems = {url = "https://github.com/Sienna-Platform/PowerSystems.jl", rev = "lk/loss-curve-type"}
 PowerTableDataParser = {url = "https://github.com/NLR-Sienna/PowerTableDataParser.jl", rev = "psy6"}

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -39,6 +39,6 @@ PowerOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIMode
 PowerOperationsOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "main", subdir = "PowerOperationsOpenAPIModels.jl"}
 InfrastructureSystems = {url = "https://github.com/Sienna-Platform/InfrastructureSystems.jl.git", rev = "IS4"}
 PowerFlowFileParser = {url = "https://github.com/Sienna-Platform/PowerFlowFileParser.jl", rev = "psy6"}
-PowerSystems = {url = "https://github.com/Sienna-Platform/PowerSystems.jl", rev = "psy6"}
+PowerSystems = {url = "https://github.com/Sienna-Platform/PowerSystems.jl", rev = "lk/loss-curve-type"}
 PowerTableDataParser = {url = "https://github.com/NLR-Sienna/PowerTableDataParser.jl", rev = "psy6"}
 


### PR DESCRIPTION
[PSY PR](https://github.com/Sienna-Platform/PowerSystems.jl) changes loss curves to their own type instead of using a `ValueCurve`, so that they can carry a units indicator (system/device/natural). This PR updates the test systems appropriately.

| File | Sites |
|---|---|
| `src/parsers/power_models_data.jl` | `loss` ×2, `converter_loss_from`, `converter_loss_to` |
| `src/library/psi_library.jl` | `loss`, `loss_function` ×2 |

Since units weren't dictated before, I assumed `NaturalUnit` throughout. (For some, that's correct from the docstring; others--VSC line from/to--don't specify.)

**Merge before** the PSY PR, which pins this branch in `test/Project.toml` until it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014eHyC9XpEJSiH27VsFcQr4