### PR TITLE
Read the switched shunt's BINIT and engaged blocks from their own keys

### DIFF
--- a/src/parsers/power_models_data.jl
+++ b/src/parsers/power_models_data.jl
@@ -1930,8 +1930,13 @@ function make_switched_shunt(name::String, d::Dict, bus::ACBus)
         :ext => d["ext"],
     )
 
-    if haskey(d, "initial_status")
-        params[:initial_status] = d["initial_status"]
+    if haskey(d, "number_engaged")
+        params[:number_engaged] = d["number_engaged"]
+    end
+    # PSS/E BINIT, carried in its own key since PowerSystems.jl#1774. Per-unit on the system
+    # base like `gs`/`bs`/`y_increment` above, all rescaled together in pm_io/data.jl.
+    if haskey(d, "solved_admittance")
+        params[:solved_admittance] = d["solved_admittance"]
     end
 
     return SwitchedAdmittance(; params...)


### PR DESCRIPTION
Completes the data-model layer of Sienna-Platform/PowerSystems.jl#1774, alongside **SiennaSchemas#44 (merged)**, PowerSystems.jl#1789 and PowerFlowFileParser.jl#55.

> [!IMPORTANT]
> **Merge order matters, and CI here will fail until the ones above land.** This reads keys that only [PowerFlowFileParser.jl#55](https://github.com/Sienna-Platform/PowerFlowFileParser.jl/pull/55) produces, and sets fields that only Sienna-Platform/PowerSystems.jl#1789 defines. `test/Project.toml` pins both to `psy6`, so until those merge the pins resolve to versions without the rename.
>
> Both upstream PRs are themselves blocked on PowerOpenAPIModels regenerating against #44 — and that is currently stuck: `update-schema.yml` starts with `gh release view --repo Sienna-Platform/SiennaSchemas`, the repo has no releases or tags, and the job exits 1. Every scheduled run for days is `completed/failure`. **Someone needs to cut a SiennaSchemas release.**

## Why this needs its own change

`make_system(pm_data)` builds `SwitchedAdmittance` **directly from the pm dict**, bypassing OpenAPI entirely — it is a second, independent RAW → PSY path alongside the parser's OpenAPI document route. So the field changes do not reach it for free.

The failure mode if it is missed is quiet rather than loud: `haskey(d, "initial_status")` simply stops matching, the component still constructs, and every RAW-built switched shunt silently loses **both** its block status and its solved admittance. Nothing errors. That is the argument for making it a visible change rather than a footnote in the parser PR.

## The change

```julia
if haskey(d, "number_engaged")
    params[:number_engaged] = d["number_engaged"]
end
if haskey(d, "solved_admittance")
    params[:solved_admittance] = d["solved_admittance"]
end
```

Both are per-unit on the system base, like the `gs`/`bs`/`y_increment` read just above — PowerFlowFileParser's `_make_per_unit!` rescales all of them together, including the new key.

## Verification

Because this repo's own pins point at `psy6`, I verified through an environment carrying the paired branches (PSY `lk/issue-1774-switched-admittance`, PFFP `lk/issue-1774-switched-shunt-binit`), parsing a real RAW end to end:

```
case14.raw
  9-1
    Y                 = 0.0 + 0.0im     ← BINIT no longer lands here
    solved_admittance = 0.19            ← BINIT, in its own field
    number_engaged    = [0]             ← pre-v35: no per-block information
    Y_increase        = [0.0 + 0.19im]
  AC power flow converged = true
```

That is the whole point of #1774 in one component: BINIT used to go into `Y`, the block status was zeroed as a sentinel to stop it double-counting, and consumers had to reverse-engineer which convention they were looking at.

## Related

- Sienna-Platform/SiennaSchemas#44 — schema (merged)
- Sienna-Platform/PowerSystems.jl#1789 — PSY struct + OpenAPI converters
- Sienna-Platform/PowerFlowFileParser.jl#55 — parser
- Sienna-Platform/PowerSystems.jl#1774 — the issue
- Sienna-Platform/PowerSystems.jl#1788 — follow-up to remove/rename `Y`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
