### PR TITLE
Follow the DeviceBaseUnit -> ComponentBaseUnit rename

### DIFF
--- a/src/definitions.jl
+++ b/src/definitions.jl
@@ -73,7 +73,7 @@ name for the reader to resolve, and leaves the scaling to the consumer.
 `units` stays `nothing`: a per-unit basis is not a units label.
 """
 per_unit_of(quantity_kind::AbstractString) =
-    (unit_system = IS.DU, units = nothing, quantity_kind = quantity_kind)
+    (unit_system = IS.CU, units = nothing, quantity_kind = quantity_kind)
 
 """
 The quantity a profile normalized against a reservoir's storage capacity scales to.

--- a/src/library/psi_library.jl
+++ b/src/library/psi_library.jl
@@ -561,7 +561,7 @@ function make_modified_RTS_GMLC_sys(
         sys,
     )
         PSY.get_fuel(d) == PSY.ThermalFuels.COAL &&
-            (PSY.set_ramp_limits!(d, (up = 0.001 * IS.DU, down = 0.001 * IS.DU)))
+            (PSY.set_ramp_limits!(d, (up = 0.001 * IS.CU, down = 0.001 * IS.CU)))
         if PSY.get_fuel(d) == PSY.ThermalFuels.DISTILLATE_FUEL_OIL
             PSY.remove_component!(sys, d)
             continue
@@ -570,10 +570,10 @@ function make_modified_RTS_GMLC_sys(
             PSY.get_operation_cost(d),
             PSY.get_start_up(PSY.get_operation_cost(d)) / 2.0,
         )
-        if PSY.get_rating(d, IS.DU) < 3
+        if PSY.get_rating(d, IS.CU) < 3
             PSY.set_status!(d, false)
             PSY.set_status!(d, false)
-            PSY.set_active_power!(d, 0.0 * IS.DU)
+            PSY.set_active_power!(d, 0.0 * IS.CU)
             continue
         end
         PSY.clear_services!(d)
@@ -603,8 +603,8 @@ function make_modified_RTS_GMLC_sys(
         PSY.RenewableDispatch,
         sys,
     )
-        rat_ = PSY.get_rating(g, IS.DU)
-        PSY.set_rating!(g, DISPATCH_INCREASE * rat_ * IS.DU)
+        rat_ = PSY.get_rating(g, IS.CU)
+        PSY.set_rating!(g, DISPATCH_INCREASE * rat_ * IS.CU)
     end
 
     for g in PSY.get_components(
@@ -612,8 +612,8 @@ function make_modified_RTS_GMLC_sys(
         PSY.RenewableNonDispatch,
         sys,
     )
-        rat_ = PSY.get_rating(g, IS.DU)
-        PSY.set_rating!(g, FIX_DECREASE * rat_ * IS.DU)
+        rat_ = PSY.get_rating(g, IS.CU)
+        PSY.set_rating!(g, FIX_DECREASE * rat_ * IS.CU)
     end
 
     ### Update Buses to PQ that got devices removed ###

--- a/src/library/psidtest_library.jl
+++ b/src/library/psidtest_library.jl
@@ -917,7 +917,7 @@ function _consolidate_zip_model!(load::PSY.StandardLoad, bucket::Symbol)
         for b in _ZIP_BUCKETS
             value = b === bucket ? total : 0.0
             setter = getproperty(PSY, Symbol("set_", prefix, b, "_", suffix, "!"))
-            setter(load, value * IS.DU)
+            setter(load, value * IS.CU)
         end
     end
     return
@@ -937,7 +937,7 @@ function _total_zip_power(
     suffix::AbstractString,
 )
     return sum(
-        getproperty(PSY, Symbol("get_", prefix, b, "_", suffix))(load, IS.DU)
+        getproperty(PSY, Symbol("get_", prefix, b, "_", suffix))(load, IS.CU)
         for b in _ZIP_BUCKETS
     )
 end

--- a/src/parsers/power_models_data.jl
+++ b/src/parsers/power_models_data.jl
@@ -1025,7 +1025,7 @@ function make_thermal_gen(
             cost = QuadraticFunctionData(get.(Ref(coeffs), quadratic_degrees, 0)...)
             fixed = (d["ncost"] >= 1) ? last(d["cost"]) : 0.0
         end
-        cost = CostCurve(InputOutputCurve((cost)), IS.DU)
+        cost = CostCurve(InputOutputCurve((cost)), IS.CU)
         startup = d["startup"]
         shutdn = d["shutdown"]
     else

--- a/test/test_transformer_parsing.jl
+++ b/test/test_transformer_parsing.jl
@@ -62,7 +62,7 @@
                 @test PSY.get_number_of_tap_positions(w) >= 0
             end
         end
-        @test PSY.get_x_12(t, DU) != 0.0
+        @test PSY.get_x_12(t, CU) != 0.0
         @test PSY.get_star_bus(t) in get_components(ACBus, sys)
         @test all(w -> PSY.get_arc(w) in get_components(Arc, sys), get_circuits(t))
     end
@@ -77,7 +77,7 @@ end
 @testset "transformer base convention (hand-computed)" begin
     # --- 2W passthrough (case14_with_pst3w) ---
     # Every 2W record in the corpus has SBASE1-2 == system base (100), so device
-    # base == system base for 2W and DU == SU. "TRAFO 2W 1" (106-105) has
+    # base == system base for 2W and CU == SU. "TRAFO 2W 1" (106-105) has
     # raw X1-2 = 1.0e-4, CZ=1, CW=1, NOMV1=0, WINDV1=0.85, WINDV2=1.0, so the
     # device-base reactance is X1-2 * (base_power/system_base) * WINDV2^2 = 1.0e-4
     # and its tap is WINDV1/WINDV2 = 0.85. This proves the maker passes br_r/br_x
@@ -91,13 +91,13 @@ end
     t_2w1 = only(
         t for t in t2ws if isapprox(PSY.get_tap(PSY.get_circuit(t)), 0.85; atol = 1e-9)
     )
-    @test PSY.get_x(t_2w1, DU) ≈ 1.0e-4 atol = 1e-12
-    @test PSY.get_r(t_2w1, DU) ≈ 0.0 atol = 1e-12
+    @test PSY.get_x(t_2w1, CU) ≈ 1.0e-4 atol = 1e-12
+    @test PSY.get_r(t_2w1, CU) ≈ 0.0 atol = 1e-12
 
     # --- 3W discriminating proof (case4_zero_impedance_3wt) ---
     # raw 3W record 102-103-104: CZ=2 (per-pair-base pu, passthrough) with
     # SBASE1-2 = 15.00, R1-2 = 5.0e-3, X1-2 = 5.0e-2. Device (pair) base = 15,
-    # system base = 100. PSY.get_x_12(DU) must equal the raw device-base value 5.0e-2
+    # system base = 100. PSY.get_x_12(CU) must equal the raw device-base value 5.0e-2
     # (i.e. NOT rebased to system base, which would give 5.0e-2 * 15/100), and the
     # SU value is that device value converted with the 15-MVA base.
     sys4 = build_system(
@@ -108,8 +108,8 @@ end
     t = first(get_components(ThreeWindingTransformer, sys4))
     @test PowerSystems.get_base_power_12(t) == 15.0
     @test PSY.get_base_power(PSY.get_primary_circuit(t)) == 15.0
-    @test PSY.get_x_12(t, DU) ≈ 5.0e-2 atol = 1e-9
-    @test PSY.get_r_12(t, DU) ≈ 5.0e-3 atol = 1e-9
+    @test PSY.get_x_12(t, CU) ≈ 5.0e-2 atol = 1e-9
+    @test PSY.get_r_12(t, CU) ≈ 5.0e-3 atol = 1e-9
     @test PSY.get_x_12(t, SU) ≈ 5.0e-2 * (100.0 / 15.0) atol = 1e-9
 end
 
@@ -160,9 +160,9 @@ end
             # the parser converts to device pu by dividing by mva_ratio_12 =
             # base_power_12 / baseMVA = 100.0 / 100.0 = 1.0, giving g = MAG1 = 0.005 and
             # b = MAG2 = 0.00674. The maker stores the transformer-level magnetizing shunt
-            # as Complex(g, b); base_power_12 equals the system base here, so DU == SU.
+            # as Complex(g, b); base_power_12 equals the system base here, so CU == SU.
             t3w = first(get_components(ThreeWindingTransformer, sys))
-            @test PSY.get_magnetizing_shunt(t3w, DU) ≈ complex(0.005, 0.00674)
+            @test PSY.get_magnetizing_shunt(t3w, CU) ≈ complex(0.005, 0.00674)
             @test PSY.get_shunt_location(t3w) ==
                   ThreeWindingTransformerShuntLocation.PRIMARY
         end
@@ -205,7 +205,7 @@ end
     @test PSY.get_base_voltage(w_a7) == 138.0
     # B = 0 for every transformer row in this fixture, so magnetizing_shunt
     # (mapped straight from `primary_shunt`) is a pure-real zero.
-    @test PSY.get_magnetizing_shunt(t_a7, DU) == 0.0
+    @test PSY.get_magnetizing_shunt(t_a7, CU) == 0.0
 
     # A14: From Bus 109 ("Ali", 138 kV) -> To Bus 111, Tr Ratio = 1.03.
     t_a14 = get_component(TwoWindingTransformer, sys, "A14")


### PR DESCRIPTION
Follow-up to InfrastructureSystems#634 / PowerSystems#1791, which renamed the per-unit marker `DU`/`DeviceBaseUnit` to `CU`/`ComponentBaseUnit`. No shims were provided, so these are hard breaks — the bare `DU` in `test_transformer_parsing.jl` raises `UndefVarError`, and so do the qualified `IS.DU`/`PSY.DU` uses in the builders.

22 sites across five files:

| File | Sites | What |
|---|---|---|
| `test/test_transformer_parsing.jl` | 10 | bare `DU` in getter calls |
| `src/library/psi_library.jl` | 8 | getters and tagged setter values |
| `src/library/psidtest_library.jl` | 2 | getter + tagged setter value |
| `src/definitions.jl` | 1 | `unit_system` entry |
| `src/parsers/power_models_data.jl` | 1 | `CostCurve` power basis |

Deliberately out of scope:
- Prose still reading "device base" — the concept is unchanged and PSCB has four other open PRs touching these files; happy to do a terminology sweep separately.
- `IS.UnitSystem.DEVICE_BASE`. The IS rename moved only the marker singleton types; `@scoped_enum(UnitSystem, SYSTEM_BASE = 0, DEVICE_BASE = 1, NATURAL_UNITS = 2)` is untouched on IS4.

Needs PSY at `psy6` (which carries #1791) to go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LP6eB1zx4eyE3hd7tpvSue